### PR TITLE
Never fallback to browser parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const isNode = typeof window === 'undefined'
-const parse = isNode ? require('url').parse : browserParse
+const parse = require('url').parse
 
 const SCHEME_REGEX = /[a-z]+:\/\//i
 //                   1          2      3        4
@@ -24,6 +24,3 @@ module.exports = function parseDatURL (str, parseQS) {
   return parsed
 }
 
-function browserParse (str) {
-  return new URL(str)
-}


### PR DESCRIPTION
Resolves #1. Note that this does *not* remove:

```js
if (isNode) parsed.href = str // overwrite href to include actual original
```

I'm not familiar enough with why that's necessary, so I've left it alone.